### PR TITLE
Add Go2 camera access code for Phase 2 challenge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,11 @@ Add things here that future versions of me should know about this codebase.
 ## Instructions
 - Always open URLs for pull requests after creating or pushing them so the human can see them
 - Always switch back to main and pull before starting new work
+
+## Environment & Technical Notes
+- **Python/pip**: Use `python3 -m pip` instead of `pip` - the system doesn't have `pip` in PATH
+- **Unitree Go2**: 
+  - Hand controller L2 double-click disables obstacle avoidance for ball interaction
+  - Camera access via GStreamer pipeline: `udpsrc address=230.1.1.1 port=1720`
+  - Default robot IP: 192.168.12.1 (ethernet) or WiFi network GO2_XXXXXX
+  - Multiple controller types: Handheld (bimanual) and Companion (side-following)

--- a/mike/README_camera.md
+++ b/mike/README_camera.md
@@ -1,0 +1,104 @@
+# Go2 Camera Access
+
+This directory contains Python code to access and display the Unitree Go2's front camera feed.
+
+## Quick Start
+
+1. **Install dependencies:**
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. **Connect to Go2:**
+   - **Ethernet**: Connect ethernet cable between computer and Go2
+   - **WiFi**: Connect to Go2's WiFi network (SSID: GO2_XXXXXX)
+
+3. **Run the camera viewer:**
+   ```bash
+   python3 camera_access.py
+   ```
+
+## Connection Methods
+
+The script tries multiple connection methods automatically:
+
+### 1. GStreamer (Recommended for EDU)
+- Uses UDP multicast stream on port 1720
+- Requires network interface name (eth0, enp2s0, etc.)
+- Best performance and reliability
+
+### 2. RTSP Stream
+- Standard RTSP protocol
+- Default URL: `rtsp://192.168.12.1:8554/video`
+- Good compatibility
+
+### 3. HTTP Stream
+- Fallback method via HTTP
+- May have higher latency
+
+## Controls
+
+- **'q'**: Quit the application
+- **'s'**: Save screenshot 
+- **'f'**: Toggle fullscreen mode
+
+## Troubleshooting
+
+### Connection Issues
+1. **Check network interface:**
+   ```bash
+   ip link show  # Linux
+   ifconfig      # macOS
+   ```
+
+2. **Verify Go2 connection:**
+   ```bash
+   ping 192.168.12.1
+   ```
+
+3. **Check GStreamer installation:**
+   ```bash
+   gst-launch-1.0 --version
+   ```
+
+### Common Problems
+
+- **"Failed to connect via GStreamer"**: Install GStreamer development packages
+- **"No frame received"**: Check network connection and robot power
+- **High latency**: Try ethernet connection instead of WiFi
+- **Permission denied**: Run with appropriate network permissions
+
+### Platform-Specific Notes
+
+**Linux:**
+- May need to install `python3-opencv` and `gstreamer1.0-plugins-*`
+- Check firewall settings for UDP multicast
+
+**macOS:** 
+- Install GStreamer via Homebrew: `brew install gstreamer`
+- May need to allow network access in Security preferences
+
+**Windows:**
+- Install GStreamer from official website
+- Ensure Python can find GStreamer libraries
+
+## Camera Specifications
+
+- **Resolution**: 1280x720
+- **Format**: H.264 encoded
+- **Frame rate**: ~30 FPS
+- **Field of view**: Wide angle front-facing camera
+- **Protocol**: UDP multicast (GStreamer) or RTSP
+
+## Integration with Robot Control
+
+This camera access can be combined with robot control for Phase 2 of the experiment:
+
+```python
+# Example: Capture frame while controlling robot
+camera = Go2CameraClient()
+if camera.connect_gstreamer("eth0"):
+    frame = camera.get_frame()
+    # Process frame for ball detection
+    # Send movement commands to robot
+```

--- a/mike/camera_access.py
+++ b/mike/camera_access.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""
+Unitree Go2 Camera Access Script
+
+This script provides multiple methods to access and display the front camera feed
+from a Unitree Go2 robot. Choose the method that works best for your setup.
+
+Requirements:
+- opencv-python (pip install opencv-python)
+- unitree_sdk2_python (for SDK method)
+- Network connection to Go2 robot
+"""
+
+import cv2
+import numpy as np
+import sys
+import time
+import socket
+from typing import Optional
+
+class Go2CameraClient:
+    """Client for accessing Unitree Go2 front camera"""
+    
+    def __init__(self):
+        self.cap = None
+        self.is_connected = False
+    
+    def connect_gstreamer(self, interface_name: str = "eth0") -> bool:
+        """
+        Connect using GStreamer pipeline (recommended for EDU version)
+        
+        Args:
+            interface_name: Network interface name (e.g., "eth0", "enp2s0")
+        """
+        try:
+            # GStreamer pipeline for Go2 camera
+            pipeline = (
+                f"udpsrc address=230.1.1.1 port=1720 multicast-iface={interface_name} ! "
+                "application/x-rtp, media=video, encoding-name=H264 ! "
+                "rtph264depay ! "
+                "h264parse ! "
+                "avdec_h264 ! "
+                "videoconvert ! "
+                "video/x-raw,width=1280,height=720,format=BGR ! "
+                "appsink drop=1"
+            )
+            
+            print(f"Connecting to Go2 camera via GStreamer on interface {interface_name}...")
+            self.cap = cv2.VideoCapture(pipeline, cv2.CAP_GSTREAMER)
+            
+            if self.cap.isOpened():
+                self.is_connected = True
+                print("✓ Successfully connected to Go2 camera via GStreamer")
+                return True
+            else:
+                print("✗ Failed to connect via GStreamer")
+                return False
+                
+        except Exception as e:
+            print(f"✗ GStreamer connection error: {e}")
+            return False
+    
+    def connect_rtsp(self, robot_ip: str = "192.168.12.1") -> bool:
+        """
+        Connect using RTSP stream (alternative method)
+        
+        Args:
+            robot_ip: IP address of the Go2 robot
+        """
+        try:
+            rtsp_url = f"rtsp://{robot_ip}:8554/video"
+            print(f"Connecting to Go2 camera via RTSP: {rtsp_url}")
+            
+            self.cap = cv2.VideoCapture(rtsp_url)
+            
+            if self.cap.isOpened():
+                self.is_connected = True
+                print("✓ Successfully connected to Go2 camera via RTSP")
+                return True
+            else:
+                print("✗ Failed to connect via RTSP")
+                return False
+                
+        except Exception as e:
+            print(f"✗ RTSP connection error: {e}")
+            return False
+    
+    def connect_webrtc(self, robot_ip: str = "192.168.12.1") -> bool:
+        """
+        Connect using WebRTC (for WiFi connection)
+        Note: This is a simplified version - full WebRTC requires additional setup
+        
+        Args:
+            robot_ip: IP address of the Go2 robot
+        """
+        try:
+            # This would typically require aiortc or similar WebRTC library
+            # For now, we'll try a direct HTTP stream approach
+            stream_url = f"http://{robot_ip}:8080/stream"
+            print(f"Connecting to Go2 camera via HTTP stream: {stream_url}")
+            
+            self.cap = cv2.VideoCapture(stream_url)
+            
+            if self.cap.isOpened():
+                self.is_connected = True
+                print("✓ Successfully connected to Go2 camera via HTTP stream")
+                return True
+            else:
+                print("✗ Failed to connect via HTTP stream")
+                return False
+                
+        except Exception as e:
+            print(f"✗ HTTP stream connection error: {e}")
+            return False
+    
+    def get_frame(self) -> Optional[np.ndarray]:
+        """Get a single frame from the camera"""
+        if not self.is_connected or self.cap is None:
+            return None
+            
+        ret, frame = self.cap.read()
+        return frame if ret else None
+    
+    def display_stream(self, window_name: str = "Go2 Camera Feed"):
+        """Display live camera stream in a window"""
+        if not self.is_connected:
+            print("✗ Not connected to camera")
+            return
+        
+        print("📹 Starting camera stream display...")
+        print("Press 'q' to quit, 's' to save screenshot, 'f' to toggle fullscreen")
+        
+        fullscreen = False
+        frame_count = 0
+        start_time = time.time()
+        
+        while True:
+            frame = self.get_frame()
+            if frame is None:
+                print("⚠️ No frame received")
+                break
+            
+            # Add frame info overlay
+            frame_count += 1
+            elapsed = time.time() - start_time
+            fps = frame_count / elapsed if elapsed > 0 else 0
+            
+            cv2.putText(frame, f"FPS: {fps:.1f}", (10, 30), 
+                       cv2.FONT_HERSHEY_SIMPLEX, 1, (0, 255, 0), 2)
+            cv2.putText(frame, f"Frame: {frame_count}", (10, 70), 
+                       cv2.FONT_HERSHEY_SIMPLEX, 1, (0, 255, 0), 2)
+            cv2.putText(frame, "Press 'q' to quit", (10, frame.shape[0] - 10), 
+                       cv2.FONT_HERSHEY_SIMPLEX, 0.7, (255, 255, 255), 2)
+            
+            # Display frame
+            cv2.imshow(window_name, frame)
+            
+            # Handle key presses
+            key = cv2.waitKey(1) & 0xFF
+            if key == ord('q'):
+                break
+            elif key == ord('s'):
+                filename = f"go2_screenshot_{int(time.time())}.jpg"
+                cv2.imwrite(filename, frame)
+                print(f"📸 Screenshot saved: {filename}")
+            elif key == ord('f'):
+                if fullscreen:
+                    cv2.setWindowProperty(window_name, cv2.WND_PROP_FULLSCREEN, cv2.WINDOW_NORMAL)
+                    fullscreen = False
+                else:
+                    cv2.setWindowProperty(window_name, cv2.WND_PROP_FULLSCREEN, cv2.WINDOW_FULLSCREEN)
+                    fullscreen = True
+        
+        print("📹 Camera stream stopped")
+        cv2.destroyAllWindows()
+    
+    def disconnect(self):
+        """Clean up camera connection"""
+        if self.cap is not None:
+            self.cap.release()
+        cv2.destroyAllWindows()
+        self.is_connected = False
+        print("🔌 Camera disconnected")
+
+def main():
+    """Main function to run camera access"""
+    print("🐕 Unitree Go2 Camera Access")
+    print("=" * 40)
+    
+    camera = Go2CameraClient()
+    
+    # Try different connection methods
+    connection_methods = [
+        ("GStreamer (Ethernet)", lambda: camera.connect_gstreamer("eth0")),
+        ("GStreamer (enp2s0)", lambda: camera.connect_gstreamer("enp2s0")), 
+        ("RTSP Stream", lambda: camera.connect_rtsp("192.168.12.1")),
+        ("HTTP Stream", lambda: camera.connect_webrtc("192.168.12.1")),
+    ]
+    
+    connected = False
+    for name, connect_func in connection_methods:
+        print(f"\n🔄 Trying {name}...")
+        if connect_func():
+            connected = True
+            break
+    
+    if not connected:
+        print("\n❌ Could not connect to Go2 camera")
+        print("\nTroubleshooting:")
+        print("1. Ensure Go2 robot is powered on and connected")
+        print("2. Check network interface name (try: ip link show)")
+        print("3. Verify robot IP address (default: 192.168.12.1)")
+        print("4. For Ethernet: ensure cable is connected")
+        print("5. For WiFi: connect to robot's WiFi network")
+        return
+    
+    try:
+        # Display the camera stream
+        camera.display_stream()
+    except KeyboardInterrupt:
+        print("\n⚠️ Interrupted by user")
+    finally:
+        camera.disconnect()
+
+if __name__ == "__main__":
+    main()

--- a/mike/requirements.txt
+++ b/mike/requirements.txt
@@ -1,0 +1,2 @@
+opencv-python>=4.8.0
+numpy>=1.21.0

--- a/mike/simple_camera.py
+++ b/mike/simple_camera.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""
+Simple Go2 Camera Viewer
+
+A minimal script to quickly test camera access.
+Usage: python3 simple_camera.py [interface_name]
+"""
+
+import cv2
+import sys
+
+def main():
+    interface = sys.argv[1] if len(sys.argv) > 1 else "eth0"
+    
+    print(f"🐕 Connecting to Go2 camera via {interface}...")
+    
+    # GStreamer pipeline for Go2
+    pipeline = (
+        f"udpsrc address=230.1.1.1 port=1720 multicast-iface={interface} ! "
+        "application/x-rtp, media=video, encoding-name=H264 ! "
+        "rtph264depay ! h264parse ! avdec_h264 ! videoconvert ! "
+        "video/x-raw,width=1280,height=720,format=BGR ! appsink drop=1"
+    )
+    
+    cap = cv2.VideoCapture(pipeline, cv2.CAP_GSTREAMER)
+    
+    if not cap.isOpened():
+        print("❌ Failed to connect. Try:")
+        print(f"  python3 {sys.argv[0]} enp2s0")
+        print(f"  python3 {sys.argv[0]} wlan0")
+        return
+    
+    print("✅ Connected! Press 'q' to quit")
+    
+    while True:
+        ret, frame = cap.read()
+        if not ret:
+            break
+            
+        cv2.imshow("Go2 Camera", frame)
+        
+        if cv2.waitKey(1) & 0xFF == ord('q'):
+            break
+    
+    cap.release()
+    cv2.destroyAllWindows()
+    print("📹 Disconnected")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds comprehensive camera access functionality for Unitree Go2 robot
- Implements multiple connection methods: GStreamer (UDP multicast), RTSP, HTTP fallback
- Provides both full-featured and simple test scripts for camera access
- Includes detailed documentation with setup and troubleshooting guide
- Supports both Ethernet and WiFi connections to the robot

## Files Added
- `mike/camera_access.py` - Full-featured camera client with multiple connection methods
- `mike/simple_camera.py` - Minimal script for quick camera testing
- `mike/requirements.txt` - Python dependencies (opencv-python, numpy)
- `mike/README_camera.md` - Comprehensive setup and troubleshooting guide

## Features
- Real-time video display with FPS counter and frame info
- Interactive controls: 'q' to quit, 's' for screenshots, 'f' for fullscreen
- Automatic connection method detection and fallback
- Cross-platform support (Linux, macOS, Windows)
- Detailed error handling and troubleshooting information

## Test Plan
- [x] Code implements multiple connection methods for Go2 camera access
- [x] Documentation covers setup, usage, and troubleshooting
- [ ] Test camera connection with actual Go2 robot via Ethernet
- [ ] Test camera connection with actual Go2 robot via WiFi
- [ ] Verify video stream quality and frame rate
- [ ] Test interactive controls (screenshot, fullscreen)

This directly supports **Phase 2** of the experiment challenge where teams need to "establish a programmatic connection with the robot's front-facing camera."

🤖 Generated with [Claude Code](https://claude.ai/code)